### PR TITLE
Reduce invokes, more group tasks

### DIFF
--- a/recipe/magento_2_1/cache.php
+++ b/recipe/magento_2_1/cache.php
@@ -8,9 +8,9 @@ task('cache:clear:magento', function () {
     run('{{bin/php}} {{release_path}}/{{magento_bin}} cache:flush');
 });
 
-task('cache:clear', function () {
-    invoke('cache:clear:magento');
-});
+task('cache:clear', [
+    'cache:clear:magento',
+]);
 
 task('cache:clear:if-maintenance', function () {
     test('[ -f {{deploy_path}}/current/{{magento_dir}}/var/.maintenance.flag ]') ?

--- a/recipe/magento_2_2.php
+++ b/recipe/magento_2_2.php
@@ -20,20 +20,23 @@ require_once __DIR__ . '/magento_2_2/crontab.php';
 require_once __DIR__ . '/magento_2_2/files.php';
 require_once __DIR__ . '/magento_2_2/rollback.php';
 
-desc('Build Artifact');
-task('build', function () {
+task('prepare:configuration', function () {
     set('deploy_path', '.');
     set('release_path', '.');
     set('current_path', '.');
     $origStaticOptions = get('static_deploy_options');
     set('static_deploy_options', '-f ' . $origStaticOptions);
+});
 
-    invoke('files:remove-generated');
-    invoke('deploy:vendors');
-    invoke('config:remove-dev-modules');
-    invoke('files:generate');
-    invoke('artifact:package');
-})->once();
+desc('Build Artifact');
+task('build', [
+    'prepare:configuration',
+    'files:remove-generated',
+    'deploy:vendors',
+    'config:remove-dev-modules',
+    'files:generate',
+    'artifact:package',
+]);
 
 desc('Deploy artifact');
 task('deploy-artifact', [

--- a/recipe/magento_2_2/artifact.php
+++ b/recipe/magento_2_2/artifact.php
@@ -29,9 +29,13 @@ task('artifact:upload', function () {
     upload(get('artifact_path'), '{{release_path}}');
 });
 
-task('build', function () {
+task('artifact:extract', function () {
     run('tar -xzpf {{release_path}}/{{artifact_file}} -C {{release_path}};');
     run('rm -rf {{release_path}}/{{artifact_file}}');
-    invoke('files:static_assets');
-    invoke('files:permissions');
 });
+
+task('build', [
+    'artifact:extract',
+    'files:static_assets',
+    'files:permissions',
+]);


### PR DESCRIPTION
Especially in the build step deployer gets confused and stops properly executing before and after hooks when functions and invokes are used.

Making it a group task (simply executing more tasks instead of executing logic itself)

fixes this.

Thus i've removed most invokes and replaced them with separate tasks